### PR TITLE
フォントのサイズの解釈がおかしいところを修正。

### DIFF
--- a/font_rasterizer/src/context.rs
+++ b/font_rasterizer/src/context.rs
@@ -262,13 +262,15 @@ pub struct TextContext {
 
 impl Default for TextContext {
     fn default() -> Self {
+        // 読みやすい文章の目安として一行日本語30文字程度、
+        // 行間を1.5倍、文字間を1.0倍をデフォルトとして設定する。
         Self {
             direction: Direction::Horizontal,
-            row_interval: 1.0,
-            col_interval: 0.7,
+            row_interval: 1.5,
+            col_interval: 1.0,
             row_scale: 1.0,
             col_scale: 1.0,
-            max_col: 40,
+            max_col: 60,
             line_prohibited_chars: LineBoundaryProhibitedChars::default(),
             min_bound: (10.0, 5.0).into(),
             char_easings: CharEasings::default(),

--- a/font_rasterizer/src/font_converter.rs
+++ b/font_rasterizer/src/font_converter.rs
@@ -332,11 +332,6 @@ mod test {
         let faces = [
             Face::parse(FONT_DATA, 0).expect("face from slice"),
             Face::parse(EMOJI_FONT_DATA, 0).expect("face from slice"),
-            Face::parse(
-                include_bytes!("../examples/font/NotoSansMonoCJKjp-Regular.otf"),
-                0,
-            )
-            .expect("face from slice"),
         ];
 
         for face in faces.iter() {

--- a/font_rasterizer/src/layout_engine.rs
+++ b/font_rasterizer/src/layout_engine.rs
@@ -235,6 +235,11 @@ impl World for HorizontalWorld {
     }
 
     fn look_next(&mut self, adjustment: CameraAdjustment) {
+        // model がない場合は何もしない
+        if self.model_length() == 0 {
+            return;
+        }
+
         // modal の場合はフォーカスを移動させない
         if let Some(ModelMode::Modal) = self.current_model_mode() {
             self.look_current(adjustment);
@@ -245,6 +250,11 @@ impl World for HorizontalWorld {
     }
 
     fn look_prev(&mut self, adjustment: CameraAdjustment) {
+        // model がない場合は何もしない
+        if self.model_length() == 0 {
+            return;
+        }
+
         // modal の場合はフォーカスを移動させない
         if let Some(ModelMode::Modal) = self.current_model_mode() {
             self.look_current(adjustment);

--- a/font_rasterizer/src/ui/ime_input.rs
+++ b/font_rasterizer/src/ui/ime_input.rs
@@ -93,7 +93,8 @@ impl ImeInput {
                 self.text_edit.set_world_scale([
                     f32::min(
                         IME_DEFAULT_SCALE[0],
-                        1.0 / char_width * context.window_size.aspect(),
+                        /* 0.7 は感覚的な値 */
+                        0.7 / char_width * context.window_size.aspect(),
                     ),
                     IME_DEFAULT_SCALE[1],
                 ]);

--- a/font_rasterizer/src/ui/selectbox.rs
+++ b/font_rasterizer/src/ui/selectbox.rs
@@ -301,10 +301,16 @@ impl Model for SelectBox {
             | EditorOperation::BackWord => self.search_text_edit.editor_operation(op),
             // search_items_text_edit に対して操作を行う
             EditorOperation::Previous => {
+                if self.max_narrowd_options_len() == 0 {
+                    return;
+                }
                 self.current_selection =
                     (self.current_selection + narrowed_options_len - 1) % narrowed_options_len
             }
             EditorOperation::Next => {
+                if self.max_narrowd_options_len() == 0 {
+                    return;
+                }
                 self.current_selection = (self.current_selection + 1) % narrowed_options_len
             }
             EditorOperation::BufferHead => self.current_selection = 0,


### PR DESCRIPTION
あわせて、レイアウトエンジンのセレクトボックスが境界値の挙動が壊れていた部分を修正。