### PR TITLE
Update edition to 2024

### DIFF
--- a/font_collector/Cargo.toml
+++ b/font_collector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "font_collector"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/font_collector/src/convert_text.rs
+++ b/font_collector/src/convert_text.rs
@@ -1,11 +1,10 @@
 use encoding_rs::{DecoderResult, MACINTOSH, UTF_16BE};
 use rustybuzz::{
-    ttf_parser::{
-        fonts_in_collection,
-        name::{Name, Names},
-        PlatformId,
-    },
     Face,
+    ttf_parser::{
+        PlatformId, fonts_in_collection,
+        name::{Name, Names},
+    },
 };
 
 #[derive(Debug, Clone, Copy)]

--- a/font_collector/src/lib.rs
+++ b/font_collector/src/lib.rs
@@ -163,7 +163,7 @@ impl FontCollector {
         names
             .into_iter()
             .enumerate()
-            .find(|(_idx, name)| ref_font.map_or(true, |f_name| f_name == name))
+            .find(|(_idx, name)| ref_font.is_none_or(|f_name| f_name == name))
             .map(|(idx, name)| FontData {
                 font_name: name,
                 binary: data,

--- a/font_collector/src/lib.rs
+++ b/font_collector/src/lib.rs
@@ -176,6 +176,7 @@ fn system_font_dir() -> PathBuf {
     match OS {
         "windows" => PathBuf::from("C:\\Windows\\Fonts"),
         "macos" => PathBuf::from("/Library/Fonts"),
+        // FIXME: Linuxの場合はフォントがサブディレクトリに分かれていることがあるのでこのままではよろしくない
         "linux" => PathBuf::from("/usr/share/fonts"),
         _ => PathBuf::new(),
     }
@@ -239,6 +240,7 @@ impl Font {
 mod tests {
     use super::*;
 
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     #[test]
     fn test_list_font_names() {
         let mut collector = FontCollector::default();

--- a/font_rasterizer/Cargo.toml
+++ b/font_rasterizer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "font_rasterizer"
 version = "0.1.0"
 authors = ["Ryo Mitoma <mutetheradio@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/font_rasterizer/src/char_width_calcurator.rs
+++ b/font_rasterizer/src/char_width_calcurator.rs
@@ -134,8 +134,9 @@ mod test {
 
     #[test]
     fn get_width() {
-        std::env::set_var("RUST_LOG", "debug");
-        env_logger::try_init().unwrap_or_default();
+        let _ = env_logger::builder()
+            .filter_level(log::LevelFilter::Debug)
+            .try_init();
 
         let collector = FontCollector::default();
 

--- a/font_rasterizer/src/context.rs
+++ b/font_rasterizer/src/context.rs
@@ -1,4 +1,4 @@
-use std::sync::{mpsc::Sender, Arc};
+use std::sync::{Arc, mpsc::Sender};
 
 use font_collector::FontRepository;
 use log::warn;

--- a/font_rasterizer/src/font_converter.rs
+++ b/font_rasterizer/src/font_converter.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use font_collector::FontData;
-use rustybuzz::{shape, ttf_parser::GlyphId, Direction, Face, UnicodeBuffer};
+use rustybuzz::{Direction, Face, UnicodeBuffer, shape, ttf_parser::GlyphId};
 
 use crate::{
     char_width_calcurator::CharWidth,

--- a/font_rasterizer/src/svg.rs
+++ b/font_rasterizer/src/svg.rs
@@ -4,7 +4,7 @@ use log::debug;
 use svg::{
     node::element::{
         path::{Command, Data, Position},
-        tag::{Path, Polygon, Type, SVG},
+        tag::{Path, Polygon, SVG, Type},
     },
     parser::Event,
 };

--- a/font_rasterizer/src/vector_instances.rs
+++ b/font_rasterizer/src/vector_instances.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::{Debug, Display},
 };
 
-use cgmath::{num_traits::ToPrimitive, Rotation3};
+use cgmath::{Rotation3, num_traits::ToPrimitive};
 use instant::Duration;
 
 use crate::{color_theme::SolarizedColor, motion::MotionFlags, time::now_millis};

--- a/font_rasterizer_example/Cargo.toml
+++ b/font_rasterizer_example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "font_rasterizer_example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/font_rasterizer_example/src/lib.rs
+++ b/font_rasterizer_example/src/lib.rs
@@ -16,8 +16,9 @@ use font_rasterizer::{
 };
 use log::info;
 use ui_support::{
+    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
     camera::{Camera, CameraController},
-    run_support, Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
+    run_support,
 };
 use winit::event::{ElementState, MouseButton, WindowEvent};
 

--- a/font_rasterizer_example/src/main.rs
+++ b/font_rasterizer_example/src/main.rs
@@ -1,6 +1,9 @@
 use font_rasterizer_example::run;
 
 pub fn main() {
-    std::env::set_var("RUST_LOG", "support_test=debug");
+    env_logger::builder()
+        .filter_module(module_path!(), log::LevelFilter::Debug)
+        .filter_level(log::LevelFilter::Warn)
+        .init();
     pollster::block_on(run());
 }

--- a/kashikishi/Cargo.toml
+++ b/kashikishi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kashikishi"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 env_logger = { workspace = true }

--- a/kashikishi/src/main.rs
+++ b/kashikishi/src/main.rs
@@ -11,12 +11,12 @@ mod world;
 use std::{rc::Rc, sync::Mutex};
 
 use arboard::Clipboard;
-use clap::{command, Parser};
+use clap::{Parser, command};
 use font_collector::{FontCollector, FontRepository};
 use rokid_max_ext::RokidMaxAction;
 use stroke_parser::{
-    action_store_parser::parse_setting, Action, ActionArgument, ActionStore, CommandName,
-    CommandNamespace,
+    Action, ActionArgument, ActionStore, CommandName, CommandNamespace,
+    action_store_parser::parse_setting,
 };
 use text_buffer::action::EditorOperation;
 use world::{CategorizedMemosWorld, HelpWorld, ModalWorld, NullWorld, StartWorld};
@@ -31,13 +31,13 @@ use font_rasterizer::{
 };
 use log::info;
 use ui_support::{
+    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
     action::{ActionProcessor, ActionProcessorStore},
     action_recorder::{ActionRecorder, InMemoryActionRecordRepository},
     camera::{Camera, CameraAdjustment, CameraOperation},
     layout_engine::{Model, ModelOperation, World},
     run_support,
-    ui::{caret_char, ime_chars, ImeInput},
-    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
+    ui::{ImeInput, caret_char, ime_chars},
 };
 use winit::event::WindowEvent;
 

--- a/kashikishi/src/rokid_max_ext.rs
+++ b/kashikishi/src/rokid_max_ext.rs
@@ -5,7 +5,7 @@ use font_rasterizer::context::StateContext;
 use rokid_3dof::RokidMax;
 use stroke_parser::{ActionArgument, CommandName, CommandNamespace};
 use ui_support::{
-    action::NamespaceActionProcessors, camera::CameraOperation, layout_engine::World, InputResult,
+    InputResult, action::NamespaceActionProcessors, camera::CameraOperation, layout_engine::World,
 };
 
 static NAMES: LazyLock<Vec<CommandName>> =

--- a/kashikishi/src/world/categorized_memos_world.rs
+++ b/kashikishi/src/world/categorized_memos_world.rs
@@ -7,10 +7,10 @@ use font_rasterizer::{
 use stroke_parser::{Action, ActionArgument};
 use text_buffer::action::EditorOperation;
 use ui_support::{
+    InputResult,
     camera::CameraAdjustment,
     layout_engine::{DefaultWorld, Model, ModelOperation, World},
     ui::TextEdit,
-    InputResult,
 };
 
 use crate::{

--- a/kashikishi/src/world/help_world.rs
+++ b/kashikishi/src/world/help_world.rs
@@ -5,10 +5,10 @@ use font_rasterizer::{
     glyph_vertex_buffer::Direction,
 };
 use ui_support::{
+    InputResult,
     camera::CameraAdjustment,
     layout_engine::{DefaultWorld, Model, World},
     ui::TextEdit,
-    InputResult,
 };
 
 use stroke_parser::Action;

--- a/kashikishi/src/world/mod.rs
+++ b/kashikishi/src/world/mod.rs
@@ -12,8 +12,8 @@ use std::collections::HashSet;
 
 use font_rasterizer::context::StateContext;
 use ui_support::{
-    layout_engine::{Model, World},
     InputResult,
+    layout_engine::{Model, World},
 };
 
 use stroke_parser::Action;

--- a/kashikishi/src/world/null_world.rs
+++ b/kashikishi/src/world/null_world.rs
@@ -5,9 +5,9 @@ use font_rasterizer::{
     glyph_vertex_buffer::Direction,
 };
 use ui_support::{
+    InputResult,
     camera::CameraAdjustment,
     layout_engine::{DefaultWorld, Model, World},
-    InputResult,
 };
 
 use stroke_parser::Action;

--- a/kashikishi/src/world/start_world.rs
+++ b/kashikishi/src/world/start_world.rs
@@ -2,10 +2,10 @@ use std::collections::HashSet;
 
 use font_rasterizer::{context::StateContext, glyph_vertex_buffer::Direction};
 use ui_support::{
+    InputResult,
     camera::CameraAdjustment,
     layout_engine::{DefaultWorld, Model, World},
     ui::{SelectBox, SelectOption},
-    InputResult,
 };
 
 use stroke_parser::Action;

--- a/rokid_3dof/Cargo.toml
+++ b/rokid_3dof/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rokid_3dof"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/rokid_3dof/examples/rokid_test.rs
+++ b/rokid_3dof/examples/rokid_test.rs
@@ -15,8 +15,9 @@ use font_rasterizer::{
     vector_instances::InstanceAttributes,
 };
 use ui_support::{
+    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
     camera::{Camera, CameraController},
-    run_support, Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
+    run_support,
 };
 
 use log::info;
@@ -26,7 +27,6 @@ const FONT_DATA: &[u8] = include_bytes!("../../fonts/BIZUDMincho-Regular.ttf");
 const EMOJI_FONT_DATA: &[u8] = include_bytes!("../../fonts/NotoEmoji-Regular.ttf");
 
 pub fn main() {
-    std::env::set_var("RUST_LOG", "support_test=debug");
     pollster::block_on(run());
 }
 

--- a/rokid_3dof/src/lib.rs
+++ b/rokid_3dof/src/lib.rs
@@ -27,18 +27,20 @@ impl RokidMax {
         };
         result.reset();
         let ahrs = result.ahrs.clone();
-        let _thread = thread::spawn(move || loop {
-            thread::sleep(std::time::Duration::from_millis(10));
-            let Ok(packet) = read_packet(&device) else {
-                continue;
-            };
-            match packet {
-                RokidMaxPacket::Combined(packet) => {
-                    if let Ok(mut vqf) = ahrs.lock() {
-                        update_vqf(&mut vqf, packet);
+        let _thread = thread::spawn(move || {
+            loop {
+                thread::sleep(std::time::Duration::from_millis(10));
+                let Ok(packet) = read_packet(&device) else {
+                    continue;
+                };
+                match packet {
+                    RokidMaxPacket::Combined(packet) => {
+                        if let Ok(mut vqf) = ahrs.lock() {
+                            update_vqf(&mut vqf, packet);
+                        }
                     }
+                    _ => { /* noop */ }
                 }
-                _ => { /* noop */ }
             }
         });
         Ok(result)

--- a/sample_codes/showcase/Cargo.toml
+++ b/sample_codes/showcase/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "showcase"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/sample_codes/showcase/src/lib.rs
+++ b/sample_codes/showcase/src/lib.rs
@@ -1,7 +1,7 @@
-use std::sync::{mpsc::Sender, LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex, mpsc::Sender};
 
 use font_collector::FontRepository;
-use stroke_parser::{action_store_parser::parse_setting, Action, ActionStore};
+use stroke_parser::{Action, ActionStore, action_store_parser::parse_setting};
 use text_buffer::action::EditorOperation;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -13,13 +13,13 @@ use font_rasterizer::{
     rasterizer_pipeline::Quarity,
 };
 use ui_support::{
+    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
     action::ActionProcessorStore,
     camera::{Camera, CameraAdjustment},
     layout_engine::{DefaultWorld, Model, World},
     run_support,
-    ui::{caret_char, ImeInput, TextEdit},
+    ui::{ImeInput, TextEdit, caret_char},
     ui_context::TextContext,
-    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
 };
 use winit::event::WindowEvent;
 

--- a/sample_codes/showcase/src/main.rs
+++ b/sample_codes/showcase/src/main.rs
@@ -1,6 +1,9 @@
 use showcase::run;
 
 fn main() {
-    std::env::set_var("RUST_LOG", "support_test=debug");
+    env_logger::builder()
+        .filter_module(module_path!(), log::LevelFilter::Debug)
+        .filter_level(log::LevelFilter::Warn)
+        .init();
     pollster::block_on(run());
 }

--- a/sample_codes/win_hello/Cargo.toml
+++ b/sample_codes/win_hello/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "win_hello"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sample_codes/win_hello/src/main.rs
+++ b/sample_codes/win_hello/src/main.rs
@@ -8,7 +8,6 @@ fn main() {
 #[cfg(target_os = "windows")]
 mod windows {
     use windows::{
-        core::{factory, h, s, Result},
         Foundation::IAsyncOperation,
         Security::Credentials::{KeyCredentialCreationOption, KeyCredentialManager, UI::*},
         Win32::{
@@ -16,6 +15,7 @@ mod windows {
             System::WinRT::IUserConsentVerifierInterop,
             UI::WindowsAndMessaging::{FindWindowA, SetForegroundWindow},
         },
+        core::{Result, factory, h, s},
     };
     use winit::{
         dpi::PhysicalSize,

--- a/stroke_parser/Cargo.toml
+++ b/stroke_parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stroke_parser"
 version = "0.1.0"
 authors = ["mitoma <mutetheradio@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 winit = { workspace = true }

--- a/stroke_parser/examples/simple_editor.rs
+++ b/stroke_parser/examples/simple_editor.rs
@@ -1,4 +1,4 @@
-use stroke_parser::{action_store_parser, Action, ActionStore};
+use stroke_parser::{Action, ActionStore, action_store_parser};
 use text_buffer::{action::EditorOperation, editor::ChangeEvent};
 use winit::{
     event::{Event, WindowEvent},

--- a/stroke_parser/src/action_store_parser.rs
+++ b/stroke_parser/src/action_store_parser.rs
@@ -1,4 +1,4 @@
-use crate::{keys, pointing_device, Action, InputWithModifier, KeyBind, Stroke};
+use crate::{Action, InputWithModifier, KeyBind, Stroke, keys, pointing_device};
 
 pub fn parse_setting(setting_string: &str) -> Vec<KeyBind> {
     let mut result: Vec<KeyBind> = Vec::new();

--- a/text_buffer/Cargo.toml
+++ b/text_buffer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "text_buffer"
 version = "0.1.0"
 authors = ["mitoma <mutetheradio@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 

--- a/text_buffer/src/editor.rs
+++ b/text_buffer/src/editor.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
-use std::sync::mpsc::Sender;
 use std::sync::Arc;
+use std::sync::mpsc::Sender;
 
 use super::action::*;
 use super::buffer::*;
@@ -381,11 +381,7 @@ mod tests {
     impl CharWidthResolver for TestWidthResolver {
         fn resolve_width(&self, c: char) -> usize {
             // テスト用なので雑に判定
-            if c.is_ascii() {
-                1
-            } else {
-                2
-            }
+            if c.is_ascii() { 1 } else { 2 }
         }
     }
 

--- a/ui_support/Cargo.toml
+++ b/ui_support/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ui_support"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 env_logger = { workspace = true }

--- a/ui_support/examples/save_apng.rs
+++ b/ui_support/examples/save_apng.rs
@@ -1,4 +1,4 @@
-use apng::{load_dynamic_image, Frame, ParallelEncoder};
+use apng::{Frame, ParallelEncoder, load_dynamic_image};
 use font_collector::{FontCollector, FontRepository};
 use instant::Duration;
 
@@ -14,8 +14,9 @@ use font_rasterizer::{
 };
 use log::{debug, info};
 use ui_support::{
+    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
     camera::{Camera, CameraController},
-    generate_image_iter, Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
+    generate_image_iter,
 };
 use winit::event::WindowEvent;
 
@@ -23,11 +24,10 @@ use winit::event::WindowEvent;
 //const EMOJI_FONT_DATA: &[u8] = include_bytes!("font/NotoEmoji-Regular.ttf");
 
 pub fn main() {
-    std::env::set_var("RUST_LOG", "info");
     env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
         .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
         .init();
-    //env_logger::init();
     pollster::block_on(run());
 }
 

--- a/ui_support/examples/save_apng2.rs
+++ b/ui_support/examples/save_apng2.rs
@@ -1,4 +1,4 @@
-use apng::{load_dynamic_image, Frame, ParallelEncoder};
+use apng::{Frame, ParallelEncoder, load_dynamic_image};
 use font_collector::{FontCollector, FontRepository};
 use instant::Duration;
 
@@ -12,21 +12,20 @@ use log::info;
 use stroke_parser::Action;
 use text_buffer::action::EditorOperation;
 use ui_support::{
+    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
     action::ActionProcessorStore,
     camera::{Camera, CameraAdjustment},
     generate_image_iter,
     layout_engine::{DefaultWorld, ModelOperation, World},
     ui::TextEdit,
-    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
 };
 use winit::event::WindowEvent;
 
 pub fn main() {
-    std::env::set_var("RUST_LOG", "info");
     env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
         .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
         .init();
-    //env_logger::init();
     pollster::block_on(run());
 }
 

--- a/ui_support/examples/save_gif.rs
+++ b/ui_support/examples/save_gif.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 
 use font_collector::{FontCollector, FontRepository};
-use image::{codecs::gif::GifEncoder, Delay, Frame};
+use image::{Delay, Frame, codecs::gif::GifEncoder};
 use instant::Duration;
 
 use font_rasterizer::{
@@ -14,21 +14,20 @@ use log::info;
 use stroke_parser::Action;
 use text_buffer::action::EditorOperation;
 use ui_support::{
+    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
     action::ActionProcessorStore,
     camera::{Camera, CameraAdjustment},
     generate_image_iter,
     layout_engine::{DefaultWorld, ModelOperation, World},
     ui::TextEdit,
-    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
 };
 use winit::event::WindowEvent;
 
 pub fn main() {
-    std::env::set_var("RUST_LOG", "info");
     env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
         .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
         .init();
-    //env_logger::init();
     pollster::block_on(run());
 }
 

--- a/ui_support/examples/setup_glyphs.rs
+++ b/ui_support/examples/setup_glyphs.rs
@@ -7,14 +7,17 @@ use font_rasterizer::{
 };
 use instant::Instant;
 use ui_support::{
-    camera::Camera, run_support, Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
+    Flags, InputResult, SimpleStateCallback, SimpleStateSupport, camera::Camera, run_support,
 };
 use winit::event::WindowEvent;
 
 const EMOJI_FONT_DATA: &[u8] = include_bytes!("../../fonts/NotoEmoji-Regular.ttf");
 
 pub fn main() {
-    std::env::set_var("RUST_LOG", "support_test=debug");
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
+        .init();
     pollster::block_on(run());
 }
 

--- a/ui_support/examples/support_test.rs
+++ b/ui_support/examples/support_test.rs
@@ -1,8 +1,9 @@
 use font_collector::FontRepository;
 use instant::Duration;
 use ui_support::{
+    Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
     camera::{Camera, CameraController},
-    run_support, Flags, InputResult, SimpleStateCallback, SimpleStateSupport,
+    run_support,
 };
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -24,7 +25,10 @@ const FONT_DATA: &[u8] = include_bytes!("../../fonts/BIZUDMincho-Regular.ttf");
 const EMOJI_FONT_DATA: &[u8] = include_bytes!("../../fonts/NotoEmoji-Regular.ttf");
 
 pub fn main() {
-    std::env::set_var("RUST_LOG", "support_test=debug");
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
+        .init();
     pollster::block_on(run());
 }
 

--- a/ui_support/src/action_recorder.rs
+++ b/ui_support/src/action_recorder.rs
@@ -1,10 +1,10 @@
 use std::{collections::VecDeque, io::BufReader, path::Path, sync::LazyLock};
 
 use font_rasterizer::{context::StateContext, time::now_millis};
-use serde_jsonlines::{write_json_lines, BufReadExt};
+use serde_jsonlines::{BufReadExt, write_json_lines};
 use stroke_parser::{Action, ActionArgument, CommandName};
 
-use crate::{action::NamespaceActionProcessors, InputResult};
+use crate::{InputResult, action::NamespaceActionProcessors};
 
 const SCRIPT_NAME: &str = "record.jsonl";
 

--- a/ui_support/src/lib.rs
+++ b/ui_support/src/lib.rs
@@ -10,6 +10,7 @@ mod text_instances;
 pub mod ui;
 pub mod ui_context;
 
+use log::warn;
 pub use render_state::RenderTargetResponse;
 
 use std::sync::Arc;
@@ -21,7 +22,7 @@ use font_rasterizer::{
     glyph_instances::GlyphInstances,
     glyph_vertex_buffer::Direction,
     rasterizer_pipeline::Quarity,
-    time::{increment_fixed_clock, set_clock_mode, ClockMode},
+    time::{ClockMode, increment_fixed_clock, set_clock_mode},
 };
 use render_state::{RenderState, RenderTargetRequest};
 
@@ -73,7 +74,10 @@ pub async fn run_support(support: SimpleStateSupport) {
             std::panic::set_hook(Box::new(console_error_panic_hook::hook));
             console_log::init_with_level(log::Level::Warn).expect("Could't initialize logger");
         } else {
-            env_logger::try_init().unwrap_or_default();
+            match env_logger::try_init() {
+                Ok(_) => {},
+                Err(_) => warn!("Logger is already initialized"),
+            }
             use std::io::Write;
             let default_hook = std::panic::take_hook();
             std::panic::set_hook(Box::new(move |info| {

--- a/ui_support/src/render_state.rs
+++ b/ui_support/src/render_state.rs
@@ -1,4 +1,4 @@
-use std::sync::{mpsc::Receiver, Arc};
+use std::sync::{Arc, mpsc::Receiver};
 
 use font_collector::FontRepository;
 use font_rasterizer::{
@@ -12,8 +12,8 @@ use image::{DynamicImage, ImageBuffer, Rgba};
 use log::info;
 
 use crate::{
-    easing_value::EasingPointN, metrics_counter::record_start_of_phase, InputResult,
-    SimpleStateCallback,
+    InputResult, SimpleStateCallback, easing_value::EasingPointN,
+    metrics_counter::record_start_of_phase,
 };
 
 use stroke_parser::Action;
@@ -85,13 +85,13 @@ impl RenderTarget {
     }
 
     fn pre_submit(&mut self, encoder: &mut wgpu::CommandEncoder, context: &StateContext) {
-        match self {
+        match &self {
             RenderTarget::Window { .. } => {
                 // 何もしない
             }
             RenderTarget::Image {
-                ref surface_texture,
-                ref output_buffer,
+                surface_texture,
+                output_buffer,
             } => {
                 let size = context.window_size;
                 let u32_size = std::mem::size_of::<u32>() as u32;
@@ -128,9 +128,7 @@ impl RenderTarget {
                 surface_texture.take().unwrap().present();
                 RenderTargetResponse::Window
             }
-            RenderTarget::Image {
-                ref output_buffer, ..
-            } => {
+            RenderTarget::Image { output_buffer, .. } => {
                 let size = context.window_size;
                 let buffer = {
                     let buffer_slice = output_buffer.slice(..);

--- a/ui_support/src/ui/mod.rs
+++ b/ui_support/src/ui/mod.rs
@@ -17,7 +17,7 @@ pub use textedit::TextEdit;
 
 use std::collections::BTreeMap;
 
-use cgmath::{num_traits::ToPrimitive, Point3, Quaternion, Rotation3};
+use cgmath::{Point3, Quaternion, Rotation3, num_traits::ToPrimitive};
 use instant::Duration;
 use log::info;
 use text_buffer::caret::CaretType;

--- a/ui_support/src/ui/select_option.rs
+++ b/ui_support/src/ui/select_option.rs
@@ -46,7 +46,7 @@ impl SelectOption {
                             **namespace,
                             **name,
                             padding = " ".repeat(padding)
-                        )
+                        );
                     }
                 }
             }

--- a/ui_support/src/ui/selectbox.rs
+++ b/ui_support/src/ui/selectbox.rs
@@ -1,7 +1,7 @@
-use std::sync::{mpsc::Sender, Arc};
+use std::sync::{Arc, mpsc::Sender};
 
 use log::info;
-use similar::{capture_diff_slices, ChangeTag};
+use similar::{ChangeTag, capture_diff_slices};
 use stroke_parser::Action;
 use text_buffer::action::EditorOperation;
 

--- a/ui_support/src/ui/textedit.rs
+++ b/ui_support/src/ui/textedit.rs
@@ -1,8 +1,8 @@
 use std::{
     ops::Range,
     sync::{
-        mpsc::{Receiver, Sender},
         Arc,
+        mpsc::{Receiver, Sender},
     },
 };
 

--- a/ui_support/src/ui/view_element_state.rs
+++ b/ui_support/src/ui/view_element_state.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, ops::Range};
 
-use cgmath::{num_traits::ToPrimitive, Matrix4, Quaternion, Rotation3};
+use cgmath::{Matrix4, Quaternion, Rotation3, num_traits::ToPrimitive};
 use instant::Duration;
 use rand::Rng;
 use text_buffer::{


### PR DESCRIPTION
Rust の edition を 2024 に上げる。
まだ GitHub Actions のイメージが最新じゃないので最新になってからマージする。

フォーマッタにわりと謎の思想が入ってる…(大文字は小文字よりも先頭にする)