### PR TITLE
Temporal AA を入れてフォント描画品質を上げる

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,6 +3004,7 @@ dependencies = [
  "apng",
  "arboard",
  "bitflags 2.9.1",
+ "cached",
  "cfg-if",
  "cgmath",
  "console_error_panic_hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,6 +2984,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "typing_game"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "font_collector",
+ "font_rasterizer",
+ "log",
+ "pollster",
+ "stroke_parser",
+ "ui_support",
+ "winit",
+]
+
+[[package]]
 name = "ui_support"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,20 +2984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typing_game"
-version = "0.1.0"
-dependencies = [
- "env_logger",
- "font_collector",
- "font_rasterizer",
- "log",
- "pollster",
- "stroke_parser",
- "ui_support",
- "winit",
-]
-
-[[package]]
 name = "ui_support"
 version = "0.1.0"
 dependencies = [

--- a/font_rasterizer/src/outline_bind_group.rs
+++ b/font_rasterizer/src/outline_bind_group.rs
@@ -1,6 +1,9 @@
 use wgpu::util::DeviceExt;
 
-use crate::screen_texture::{ScreenTexture, TXAA_TEXTURE_FORMAT, TxaaTexture};
+use crate::{
+    screen_texture::{ScreenTexture, TXAA_TEXTURE_FORMAT, TxaaTexture},
+    time::frame_count,
+};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
@@ -92,7 +95,7 @@ impl OutlineBindGroup {
     }
 
     pub fn update(&mut self) {
-        self.uniforms.frame_count += 1;
+        self.uniforms.frame_count = frame_count();
     }
 
     pub fn update_buffer(&mut self, queue: &wgpu::Queue) {

--- a/font_rasterizer/src/outline_bind_group.rs
+++ b/font_rasterizer/src/outline_bind_group.rs
@@ -1,4 +1,4 @@
-use crate::screen_texture::ScreenTexture;
+use crate::screen_texture::{ScreenTexture, TXAA_TEXTURE_FORMAT, TxaaTexture};
 
 /// アウトライン用の BindGroup。
 /// Overlay 情報の書き込まれた Texture と Sampler のみを受け取る。
@@ -14,6 +14,7 @@ impl OutlineBindGroup {
     pub(crate) fn new(device: &wgpu::Device) -> Self {
         let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             entries: &[
+                // Overlay 情報の書き込まれたテクスチャ
                 wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStages::FRAGMENT,
@@ -24,10 +25,22 @@ impl OutlineBindGroup {
                     },
                     count: None,
                 },
+                // サンプラー
                 wgpu::BindGroupLayoutEntry {
                     binding: 1,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                // temporal anti aliasing 用のテクスチャ
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::StorageTexture {
+                        access: wgpu::StorageTextureAccess::ReadWrite,
+                        format: TXAA_TEXTURE_FORMAT,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                    },
                     count: None,
                 },
             ],
@@ -40,6 +53,7 @@ impl OutlineBindGroup {
         &self,
         device: &wgpu::Device,
         overlap_texture: &ScreenTexture,
+        aa_texture: &TxaaTexture,
     ) -> wgpu::BindGroup {
         device.create_bind_group(&wgpu::BindGroupDescriptor {
             layout: &self.layout,
@@ -51,6 +65,10 @@ impl OutlineBindGroup {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::Sampler(&overlap_texture.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(&aa_texture.view),
                 },
             ],
             label: Some("Outline Bind Group"),

--- a/font_rasterizer/src/outline_bind_group.rs
+++ b/font_rasterizer/src/outline_bind_group.rs
@@ -6,20 +6,11 @@ use crate::{
 };
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Debug, Default, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Uniforms {
     frame_count: u32,
     // padding が必要らしい。
     padding: [u32; 3],
-}
-
-impl Default for Uniforms {
-    fn default() -> Self {
-        Self {
-            frame_count: 0,
-            padding: [0; 3],
-        }
-    }
 }
 
 /// アウトライン用の BindGroup。

--- a/font_rasterizer/src/outline_bind_group.rs
+++ b/font_rasterizer/src/outline_bind_group.rs
@@ -1,4 +1,23 @@
+use wgpu::util::DeviceExt;
+
 use crate::screen_texture::{ScreenTexture, TXAA_TEXTURE_FORMAT, TxaaTexture};
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Uniforms {
+    frame_count: u32,
+    // padding が必要らしい。
+    padding: [u32; 3],
+}
+
+impl Default for Uniforms {
+    fn default() -> Self {
+        Self {
+            frame_count: 0,
+            padding: [0; 3],
+        }
+    }
+}
 
 /// アウトライン用の BindGroup。
 /// Overlay 情報の書き込まれた Texture と Sampler のみを受け取る。
@@ -7,6 +26,8 @@ use crate::screen_texture::{ScreenTexture, TXAA_TEXTURE_FORMAT, TxaaTexture};
 /// R, G, B: 色情報
 /// A: 重ね合わせの数
 pub struct OutlineBindGroup {
+    uniforms: Uniforms,
+    buffer: wgpu::Buffer,
     pub(crate) layout: wgpu::BindGroupLayout,
 }
 
@@ -43,10 +64,39 @@ impl OutlineBindGroup {
                     },
                     count: None,
                 },
+                // Uniforms
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
             ],
             label: Some("Outline Bind Group Layout"),
         });
-        Self { layout }
+        let uniforms = Uniforms::default();
+        let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Outline Uniform Buffer"),
+            contents: bytemuck::cast_slice(&[uniforms]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        Self {
+            uniforms,
+            buffer,
+            layout,
+        }
+    }
+
+    pub fn update(&mut self) {
+        self.uniforms.frame_count += 1;
+    }
+
+    pub fn update_buffer(&mut self, queue: &wgpu::Queue) {
+        queue.write_buffer(&self.buffer, 0, bytemuck::cast_slice(&[self.uniforms]))
     }
 
     pub fn to_bind_group(
@@ -69,6 +119,10 @@ impl OutlineBindGroup {
                 wgpu::BindGroupEntry {
                     binding: 2,
                     resource: wgpu::BindingResource::TextureView(&aa_texture.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: self.buffer.as_entire_binding(),
                 },
             ],
             label: Some("Outline Bind Group"),

--- a/font_rasterizer/src/rasterizer_pipeline.rs
+++ b/font_rasterizer/src/rasterizer_pipeline.rs
@@ -414,6 +414,9 @@ impl RasterizerPipeline {
         self.overlap_bind_group.update(view_proj);
         self.overlap_bind_group.update_buffer(queue);
         self.overlap_stage(encoder, glyph_buffers, vector_buffers);
+
+        self.outline_bind_group.update();
+        self.outline_bind_group.update_buffer(queue);
         self.outline_stage(encoder, device);
 
         //self.txaa_stage(encoder, device);

--- a/font_rasterizer/src/screen_bind_group.rs
+++ b/font_rasterizer/src/screen_bind_group.rs
@@ -1,4 +1,4 @@
-use crate::screen_texture::{ScreenTexture, TxaaTexture};
+use crate::screen_texture::ScreenTexture;
 
 /// Screen用の BindGroup。
 /// Outline の Texture をアンチエイリアスする

--- a/font_rasterizer/src/screen_bind_group.rs
+++ b/font_rasterizer/src/screen_bind_group.rs
@@ -1,4 +1,4 @@
-use crate::screen_texture::ScreenTexture;
+use crate::screen_texture::{ScreenTexture, TxaaTexture};
 
 /// Screen用の BindGroup。
 /// Outline の Texture をアンチエイリアスする
@@ -27,7 +27,7 @@ impl ScreenBindGroup {
                     count: None,
                 },
             ],
-            label: Some("Outline Bind Group Layout"),
+            label: Some("Screen Bind Group Layout"),
         });
         Self { layout }
     }
@@ -59,7 +59,7 @@ impl ScreenBindGroup {
                     resource: wgpu::BindingResource::Sampler(&sampler),
                 },
             ],
-            label: Some("Outline Bind Group"),
+            label: Some("Screen Bind Group"),
         })
     }
 }

--- a/font_rasterizer/src/screen_texture.rs
+++ b/font_rasterizer/src/screen_texture.rs
@@ -52,9 +52,9 @@ impl ScreenTexture {
 pub const TXAA_TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R32Uint;
 
 pub struct TxaaTexture {
-    pub texture: wgpu::Texture,
+    pub _texture: wgpu::Texture,
     pub view: wgpu::TextureView,
-    pub texture_format: wgpu::TextureFormat,
+    pub _texture_format: wgpu::TextureFormat,
 }
 
 impl TxaaTexture {
@@ -83,9 +83,9 @@ impl TxaaTexture {
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         Self {
-            texture,
+            _texture: texture,
             view,
-            texture_format,
+            _texture_format: texture_format,
         }
     }
 }

--- a/font_rasterizer/src/screen_texture.rs
+++ b/font_rasterizer/src/screen_texture.rs
@@ -49,6 +49,47 @@ impl ScreenTexture {
     }
 }
 
+pub const TXAA_TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R32Uint;
+
+pub struct TxaaTexture {
+    pub texture: wgpu::Texture,
+    pub view: wgpu::TextureView,
+    pub texture_format: wgpu::TextureFormat,
+}
+
+impl TxaaTexture {
+    pub fn new(device: &wgpu::Device, size: (u32, u32), label: Option<&str>) -> Self {
+        let texture_format = TXAA_TEXTURE_FORMAT;
+        let size = wgpu::Extent3d {
+            width: size.0,
+            height: size.1,
+            depth_or_array_layers: 1,
+        };
+
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label,
+            size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: texture_format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::STORAGE_BINDING
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        Self {
+            texture,
+            view,
+            texture_format,
+        }
+    }
+}
+
 pub struct BackgroundImageTexture {
     pub _texture: wgpu::Texture,
     pub view: wgpu::TextureView,

--- a/font_rasterizer/src/shader/background_image_shader.wgsl
+++ b/font_rasterizer/src/shader/background_image_shader.wgsl
@@ -1,0 +1,41 @@
+// Vertex shader
+
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) tex_coords: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+}
+
+@vertex
+fn vs_main(
+    model: VertexInput,
+) -> VertexOutput {
+    var out: VertexOutput;
+    out.tex_coords = model.tex_coords;
+    out.clip_position = vec4<f32>(model.position, 1.0);
+    return out;
+}
+
+// Fragment shader
+
+@group(0) @binding(0)
+var t_diffuse: texture_2d<f32>;
+@group(0)@binding(1)
+var s_diffuse: sampler;
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    var color = textureSample(t_diffuse, s_diffuse, in.tex_coords);
+    return vignetting(in.tex_coords, color);
+}
+
+fn vignetting(tex_coords: vec2<f32>, color: vec4<f32>) -> vec4<f32> {
+    let center = vec2<f32>(0.5, 0.5);
+    let distance = length(tex_coords - center);
+    let rgb = clamp(color.rgb - vec3<f32>(distance), vec3<f32>(0.0), vec3<f32>(1.0));
+    return vec4<f32>(rgb, color.a);
+}

--- a/font_rasterizer/src/shader/outline_shader.wgsl
+++ b/font_rasterizer/src/shader/outline_shader.wgsl
@@ -23,8 +23,11 @@ fn vs_main(
 
 @group(0) @binding(0)
 var t_diffuse: texture_2d<f32>;
-@group(0)@binding(1)
+@group(0) @binding(1)
 var s_diffuse: sampler;
+// 型は f32 だが直近の奇数/偶数判定を u32 で持つ
+@group(0) @binding(2)
+var t_history_bits: texture_storage_2d<r32uint, read_write>;
 
 // UNIT = 1.0 / 256.0 
 const UNIT :f32 = 0.00390625;
@@ -78,6 +81,59 @@ fn antialias(tex_coords: vec2<f32>) -> f32 {
     return result;
 }
 
+/// f32を u32 のビット列として取得
+fn f32_to_bits(value: f32) -> u32 {
+    return bitcast<u32>(value);
+}
+
+/// u32 のビット列を f32 として解釈
+fn bits_to_f32(bits: u32) -> f32 {
+    return bitcast<f32>(bits);
+}
+
+// u32 のビット列から立っているビットの数をカウントし n/32 の f32 値を返す
+fn count_bits(bits: u32) -> f32 {
+    return f32(countOneBits(bits)) / 32.0;
+}
+
+// u32 のビット列の指定ビットの値を変更
+fn set_bit(bits: u32, bit_index: u32, value: bool) -> u32 {
+    if value {
+        return bits | (1u << bit_index);
+    } else {
+        return bits & ~(1u << bit_index);
+    }
+}
+
+/// vec4<f32> の指定した要素をビット列として取得
+fn get_component_bits(v: vec4<f32>, component: u32) -> u32 {
+    if component == 0u {
+        return bitcast<u32>(v.x);
+    } else if component == 1u {
+        return bitcast<u32>(v.y);
+    } else if component == 2u {
+        return bitcast<u32>(v.z);
+    } else {
+        return bitcast<u32>(v.w);
+    }
+}
+
+/// vec4<f32> の指定した要素にビット列から設定
+fn set_component_from_bits(v: vec4<f32>, component: u32, bits: u32) -> vec4<f32> {
+    var result = v;
+    let float_value = bitcast<f32>(bits);
+    if component == 0u {
+        result.x = float_value;
+    } else if component == 1u {
+        result.y = float_value;
+    } else if component == 2u {
+        result.z = float_value;
+    } else {
+        result.w = float_value;
+    }
+    return result;
+}
+
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // アルファ成分にテクスチャの重なりの情報を持たせている
@@ -88,6 +144,20 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     //if use_anti_alias {
     //    return vec4<f32>(color.rgb, antialias(in.tex_coords));
     //}
+
+    // テンポラルアンチエイリアスを有効にする場合
+    let use_temporal_aa = true;
+    if use_temporal_aa {
+        let current_odd = odd_color(in.tex_coords);
+
+        let ipos: vec2<i32> = vec2<i32>(floor(in.clip_position.xy));
+        var pixel_value = textureLoad(t_history_bits, ipos);
+        var odd_history_bits = pixel_value.r;
+        odd_history_bits = set_bit(odd_history_bits, 0, current_odd);
+        pixel_value.r = odd_history_bits;
+        textureStore(t_history_bits, ipos, pixel_value);
+        return vec4<f32>(color.rgb, f32(countOneBits(odd_history_bits)) / 32.0);
+    }
 
     // 奇数かどうかを判定し、奇数なら色をつける
     if odd_color(in.tex_coords) {

--- a/font_rasterizer/src/shader/outline_shader.wgsl
+++ b/font_rasterizer/src/shader/outline_shader.wgsl
@@ -29,6 +29,13 @@ var s_diffuse: sampler;
 @group(0) @binding(2)
 var t_history_bits: texture_storage_2d<r32uint, read_write>;
 
+struct Uniforms {
+    frame_count: u32,
+};
+
+@group(0) @binding(3)
+var<uniform> u_buffer: Uniforms;
+
 // UNIT = 1.0 / 256.0 
 const UNIT :f32 = 0.00390625;
 const HARFUNIT: f32 = 0.001953125;
@@ -153,7 +160,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         let ipos: vec2<i32> = vec2<i32>(floor(in.clip_position.xy));
         var pixel_value = textureLoad(t_history_bits, ipos);
         var odd_history_bits = pixel_value.r;
-        odd_history_bits = set_bit(odd_history_bits, 0, current_odd);
+        odd_history_bits = set_bit(odd_history_bits, u_buffer.frame_count % 32, current_odd);
         pixel_value.r = odd_history_bits;
         textureStore(t_history_bits, ipos, pixel_value);
         return vec4<f32>(color.rgb, f32(countOneBits(odd_history_bits)) / 32.0);

--- a/ui_support/Cargo.toml
+++ b/ui_support/Cargo.toml
@@ -22,6 +22,7 @@ font_collector = { path = "../font_collector" }
 stroke_parser = { path = "../stroke_parser" }
 text_buffer = { path = "../text_buffer" }
 serde-jsonlines = "0.7.0"
+cached = "0.55.1"
 
 similar = "2.6.0"
 

--- a/ui_support/src/camera.rs
+++ b/ui_support/src/camera.rs
@@ -43,6 +43,7 @@ impl Camera {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         eye: EasingPointN<3>,    // 視点の位置
         target: EasingPointN<3>, // ターゲットの位置

--- a/ui_support/src/halton.rs
+++ b/ui_support/src/halton.rs
@@ -1,0 +1,32 @@
+use cached::proc_macro::cached;
+
+// Halton Sequence
+#[cached]
+pub(crate) fn halton_sequence(base: u32, index: u32) -> f32 {
+    let mut result = 0.0;
+    let mut f = 1.0;
+    let mut i = index;
+
+    while i > 0 {
+        f /= base as f32;
+        result += f * (i % base) as f32;
+        i /= base;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::halton::halton_sequence;
+
+    #[test]
+    fn test_halton_sequence() {
+        assert_eq!(halton_sequence(2, 0), 0.0);
+        assert_eq!(halton_sequence(2, 1), 0.5);
+        assert_eq!(halton_sequence(2, 2), 0.25);
+        assert_eq!(halton_sequence(3, 0), 0.0);
+        assert_eq!(halton_sequence(3, 1), 1.0 / 3.0);
+        assert_eq!(halton_sequence(3, 2), 2.0 / 3.0);
+    }
+}

--- a/ui_support/src/lib.rs
+++ b/ui_support/src/lib.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod action_recorder;
 pub mod camera;
 mod easing_value;
+mod halton;
 pub mod layout_engine;
 mod metrics_counter;
 mod render_rate_adjuster;

--- a/ui_support/src/render_state.rs
+++ b/ui_support/src/render_state.rs
@@ -219,7 +219,8 @@ impl RenderState {
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 label: None,
-                required_features: wgpu::Features::empty(),
+                required_features: wgpu::Features::empty()
+                    | wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
                 // WebGL doesn't support all of wgpu's features, so if
                 // we're building for the web we'll have to disable some.
                 required_limits: if cfg!(target_arch = "wasm32") {


### PR DESCRIPTION
この Pull Request の実装ポイント

- カメラが各フレームで1ピクセル以下の振動を32フレーム周期で行うようにする
  - 振動が 1 ピクセルの空間をまんべんなく埋めるようにハルトン列を用いる
- Storage Texture を使い、アウトラインを塗りつぶすかどうかを直近 32 フレーム分記録する
  - u32で 1frame 1bit で記録していく
- レンダリング時に直近 32 フレームの結果から 32 階調の透過度を計算することでエッジの滑らかな描画を狙う

実装してみての評価結果としては以下の通り。

- 直近 32 フレームだと残像がきつくて実用にはならない
- 色を render target のみ記録すると中心から遠い側のエッジの色がグリフの色にならず、レンダリング結果が振動してしまう

結論としてこの Pull Request は採用をしない。
ただし Storage Texture の利用が有効である事が分かったため、overlay ステージと outline ステージを統一することを検討する。