### PR TITLE
add mise file

### DIFF
--- a/mise.debug.toml
+++ b/mise.debug.toml
@@ -1,0 +1,6 @@
+[env]
+FONT_RASTERIZER_DEBUG = "true"
+
+[tasks.example]
+description = "example task"
+run = "echo 'Hello'"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,22 @@
+[tools]
+rust = "1.87.0"
+
+[tasks.kashikishi]
+description = "Run the kashikishi"
+run = "cargo run --bin kashikishi --release"
+
+[tasks.fmt]
+description = "Format the code"
+run = "cargo fmt --all"
+
+[tasks.clippy]
+description = "Run clippy"
+run = "cargo clippy --all -- -D clippy::all"
+
+[tasks.test]
+description = "Run tests"
+run = "cargo test --all"
+
+[tasks.check]
+description = "Run checks"
+depends = ["fmt", "clippy", "test"]


### PR DESCRIPTION
とりあえず mise を入れてみる。

CI に対応はスコープ外にする。

スコープに入れるには以下の2点が解消される必要がある。
- rust の experimental が取れる
- アーカイブを作るときに複数の Rust を扱ったり OS 依存の扱い方の方針が定まる