### PR TITLE
フォントキャッシュ機能の実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "cfg-if",
  "console_error_panic_hook",
  "console_log",
+ "dirs",
  "env_logger",
  "font_collector",
  "fs_extra",
@@ -1069,6 +1070,7 @@ dependencies = [
  "image",
  "log",
  "rand 0.10.1",
+ "redb",
  "rustybuzz",
  "text_buffer",
  "thiserror 2.0.18",
@@ -2577,6 +2579,15 @@ version = "0.1.0"
 source = "git+https://github.com/mitoma/sandbox?branch=main#b47ba9cc112ea6dc27ec826db49c80b394e21904"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.6.3"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+checksum = "67f7f231ea7b1172b7ac00ccf96b1250f0fb5a16d5585836aa4ebc997df7cbde"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ tree-sitter-json = "0.24.8"
 tree-sitter-bash = "0.25.0"
 tree-sitter-toml-ng = "0.7.0"
 
-redb = "2"
+redb = "4.0.0"
 rayon = "1.12.0"
 apng = { git = "https://github.com/mitoma/apng", branch = "master" }
 fs_extra = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ tree-sitter-json = "0.24.8"
 tree-sitter-bash = "0.25.0"
 tree-sitter-toml-ng = "0.7.0"
 
+redb = "2"
 rayon = "1.12.0"
 apng = { git = "https://github.com/mitoma/apng", branch = "master" }
 fs_extra = "1.3.0"

--- a/font_rasterizer/Cargo.toml
+++ b/font_rasterizer/Cargo.toml
@@ -4,10 +4,15 @@ version = "0.1.0"
 authors = ["Ryo Mitoma <mutetheradio@gmail.com>"]
 edition = "2024"
 
+[features]
+cache = ["dep:redb", "dep:dirs"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+redb = { workspace = true, optional = true }
+dirs = { workspace = true, optional = true }
 cfg-if = { workspace = true }
 thiserror = { workspace = true }
 env_logger = { workspace = true }

--- a/font_rasterizer/src/font_converter.rs
+++ b/font_rasterizer/src/font_converter.rs
@@ -17,11 +17,19 @@ use crate::{
 
 pub(crate) struct FontVertexConverter {
     fonts: Arc<Vec<FontData>>,
+    #[cfg(all(feature = "cache", not(target_arch = "wasm32")))]
+    cache: Option<crate::glyph_cache::GlyphCache>,
 }
 
 impl FontVertexConverter {
     pub(crate) fn new(fonts: Arc<Vec<FontData>>) -> Self {
-        Self { fonts }
+        #[cfg(all(feature = "cache", not(target_arch = "wasm32")))]
+        let cache = crate::glyph_cache::GlyphCache::open(&fonts);
+        Self {
+            fonts,
+            #[cfg(all(feature = "cache", not(target_arch = "wasm32")))]
+            cache,
+        }
     }
 
     fn is_remove_outline_fontname(fontname: &str) -> bool {
@@ -95,6 +103,26 @@ impl FontVertexConverter {
         c: char,
         width: CharWidth,
     ) -> Result<GlyphVertex, FontRasterizerError> {
+        // キャッシュヒット時はそのまま返す
+        #[cfg(all(feature = "cache", not(target_arch = "wasm32")))]
+        if let Some(cache) = &self.cache
+            && let Some(glyph) = cache.get(c, width)
+        {
+            return Ok(glyph);
+        }
+
+        let result = self.convert_inner(c, width)?;
+
+        // コンバート結果をキャッシュに保存
+        #[cfg(all(feature = "cache", not(target_arch = "wasm32")))]
+        if let Some(cache) = &self.cache {
+            cache.set(&result, width);
+        }
+
+        Ok(result)
+    }
+
+    fn convert_inner(&self, c: char, width: CharWidth) -> Result<GlyphVertex, FontRasterizerError> {
         let (
             face,
             remove_overlap,

--- a/font_rasterizer/src/glyph_cache.rs
+++ b/font_rasterizer/src/glyph_cache.rs
@@ -1,0 +1,177 @@
+use std::path::PathBuf;
+
+use font_collector::FontData;
+use redb::{Database, TableDefinition};
+
+use crate::{
+    char_width_calcurator::CharWidth,
+    font_converter::GlyphVertex,
+    vector_vertex::{VectorVertex, Vertex},
+};
+
+const GLYPH_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("glyphs");
+
+/// フォントバイナリの FNV-1a ハッシュを計算する（実行間で安定した値を返す）
+fn fonts_hash(fonts: &[FontData]) -> u64 {
+    const FNV_PRIME: u64 = 1099511628211;
+    const FNV_OFFSET: u64 = 14695981039346656037;
+    let mut hash = FNV_OFFSET;
+    for font in fonts {
+        for &byte in &font.binary {
+            hash ^= byte as u64;
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+    }
+    hash
+}
+
+fn cache_db_path(fonts: &[FontData]) -> PathBuf {
+    let hash = fonts_hash(fonts);
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("kashikishi")
+        .join(format!("glyph_cache_{hash:016x}.redb"))
+}
+
+pub(crate) struct GlyphCache {
+    db: Database,
+}
+
+impl GlyphCache {
+    /// キャッシュを開く。失敗した場合は None を返しログに警告を出す。
+    pub(crate) fn open(fonts: &[FontData]) -> Option<Self> {
+        let path = cache_db_path(fonts);
+        if let Some(parent) = path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            log::warn!("グリフキャッシュディレクトリの作成に失敗: {e}");
+            return None;
+        }
+        match Database::create(&path) {
+            Ok(db) => {
+                log::info!("グリフキャッシュを開きました: {}", path.display());
+                Some(Self { db })
+            }
+            Err(e) => {
+                log::warn!("グリフキャッシュのオープンに失敗: {e}");
+                None
+            }
+        }
+    }
+
+    fn make_key(c: char, width: CharWidth) -> [u8; 5] {
+        let c_bytes = (c as u32).to_le_bytes();
+        let w_byte = match width {
+            CharWidth::Regular => 0u8,
+            CharWidth::Wide => 1u8,
+        };
+        [c_bytes[0], c_bytes[1], c_bytes[2], c_bytes[3], w_byte]
+    }
+
+    /// キャッシュからグリフ頂点データを取得する。存在しない場合は None を返す。
+    pub(crate) fn get(&self, c: char, width: CharWidth) -> Option<GlyphVertex> {
+        let key = Self::make_key(c, width);
+        let read_txn = self.db.begin_read().ok()?;
+        let table = read_txn.open_table(GLYPH_TABLE).ok()?;
+        let guard = table.get(key.as_slice()).ok()??;
+        deserialize_glyph_vertex(guard.value())
+    }
+
+    /// グリフ頂点データをキャッシュに保存する。失敗した場合はログに警告を出す。
+    pub(crate) fn set(&self, glyph: &GlyphVertex, width: CharWidth) {
+        let key = Self::make_key(glyph.c, width);
+        let value = serialize_glyph_vertex(glyph);
+        if let Err(e) = self.set_inner(&key, &value) {
+            log::warn!("グリフキャッシュへの書き込みに失敗: {e}");
+        }
+    }
+
+    fn set_inner(
+        &self,
+        key: &[u8],
+        value: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(GLYPH_TABLE)?;
+            table.insert(key, value)?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+}
+
+// ---- シリアライズ / デシリアライズ ----
+
+fn serialize_vector_vertex(v: &VectorVertex, buf: &mut Vec<u8>) {
+    // Vertex は bytemuck::Pod なのでそのままバイト列に変換できる
+    let vertex_bytes: &[u8] = bytemuck::cast_slice(&v.vertex);
+    buf.extend_from_slice(&(v.vertex.len() as u32).to_le_bytes());
+    buf.extend_from_slice(vertex_bytes);
+    buf.extend_from_slice(&(v.index.len() as u32).to_le_bytes());
+    for &i in &v.index {
+        buf.extend_from_slice(&i.to_le_bytes());
+    }
+}
+
+fn deserialize_vector_vertex(data: &[u8], pos: &mut usize) -> Option<VectorVertex> {
+    let vertex_len = u32::from_le_bytes(data.get(*pos..*pos + 4)?.try_into().ok()?) as usize;
+    *pos += 4;
+    // bytemuck::cast_slice はアライメントを要求するため、フィールドを個別に読み出す
+    let mut vertex = Vec::with_capacity(vertex_len);
+    for _ in 0..vertex_len {
+        let x = f32::from_le_bytes(data.get(*pos..*pos + 4)?.try_into().ok()?);
+        *pos += 4;
+        let y = f32::from_le_bytes(data.get(*pos..*pos + 4)?.try_into().ok()?);
+        *pos += 4;
+        let vertex_type = u32::from_le_bytes(data.get(*pos..*pos + 4)?.try_into().ok()?);
+        *pos += 4;
+        vertex.push(Vertex {
+            position: [x, y],
+            vertex_type,
+        });
+    }
+
+    let index_len = u32::from_le_bytes(data.get(*pos..*pos + 4)?.try_into().ok()?) as usize;
+    *pos += 4;
+    let mut index = Vec::with_capacity(index_len);
+    for _ in 0..index_len {
+        index.push(u32::from_le_bytes(
+            data.get(*pos..*pos + 4)?.try_into().ok()?,
+        ));
+        *pos += 4;
+    }
+    Some(VectorVertex { vertex, index })
+}
+
+fn serialize_glyph_vertex(g: &GlyphVertex) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&(g.c as u32).to_le_bytes());
+    serialize_vector_vertex(&g.h_vertex, &mut buf);
+    match &g.v_vertex {
+        Some(v) => {
+            buf.push(1);
+            serialize_vector_vertex(v, &mut buf);
+        }
+        None => buf.push(0),
+    }
+    buf
+}
+
+fn deserialize_glyph_vertex(data: &[u8]) -> Option<GlyphVertex> {
+    let mut pos = 0;
+    let c = char::from_u32(u32::from_le_bytes(data.get(pos..pos + 4)?.try_into().ok()?))?;
+    pos += 4;
+    let h_vertex = deserialize_vector_vertex(data, &mut pos)?;
+    let v_vertex = if *data.get(pos)? == 1 {
+        pos += 1;
+        Some(deserialize_vector_vertex(data, &mut pos)?)
+    } else {
+        None
+    };
+    Some(GlyphVertex {
+        c,
+        h_vertex,
+        v_vertex,
+    })
+}

--- a/font_rasterizer/src/glyph_cache.rs
+++ b/font_rasterizer/src/glyph_cache.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use font_collector::FontData;
-use redb::{Database, TableDefinition};
+use redb::{Database, ReadableDatabase, TableDefinition};
 
 use crate::{
     char_width_calcurator::CharWidth,

--- a/font_rasterizer/src/lib.rs
+++ b/font_rasterizer/src/lib.rs
@@ -5,6 +5,8 @@ pub mod context;
 mod debug_mode;
 pub mod errors;
 pub mod font_converter;
+#[cfg(all(feature = "cache", not(target_arch = "wasm32")))]
+mod glyph_cache;
 pub mod glyph_instances;
 pub mod glyph_vertex_buffer;
 pub mod motion;

--- a/kashikishi/Cargo.toml
+++ b/kashikishi/Cargo.toml
@@ -18,7 +18,7 @@ arboard = { workspace = true }
 dirs = { workspace = true }
 
 font_collector = { path = "../font_collector" }
-font_rasterizer = { path = "../font_rasterizer" }
+font_rasterizer = { path = "../font_rasterizer", features = ["cache"] }
 text_buffer = { path = "../text_buffer" }
 stroke_parser = { path = "../stroke_parser" }
 rokid_3dof = { path = "../rokid_3dof" }


### PR DESCRIPTION
Font から GPU 用の座標データに変換する際、典型的には単に読み込むだけだが
overlap 除去処理が必要な場合にはパフォーマンスが低いことが知られているため
ネイティブ環境では redb で変換結果のキャッシュを利用する。